### PR TITLE
Add strategic insights API and update dashboard link

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -755,7 +755,7 @@ export default function AdminDashboard() {
                     </div>
                   </CardContent>
                   <CardFooter className="border-t pt-4">
-                    <Link href="/admin/ai-insights">
+                    <Link href="/admin/ai-strategy">
                       <Button variant="outline" className="gap-2">
                         <Brain className="h-4 w-4" />
                         <span>Ver análisis completo de IA</span>

--- a/docs/STRATEGIC_INSIGHTS_API.md
+++ b/docs/STRATEGIC_INSIGHTS_API.md
@@ -1,0 +1,25 @@
+# Strategic Insights API
+
+Este servicio entrega recomendaciones comerciales y operativas generadas automaticamente a partir de las métricas de la plataforma.
+
+### Endpoint
+
+`GET /api/strategic-insights`
+
+Devuelve un objeto JSON con la fecha de generación, las métricas utilizadas y una lista de sugerencias.
+
+```json
+{
+  "generatedAt": "2025-06-28T00:00:00.000Z",
+  "metrics": {
+    "users": { "totalUsers": 100, ... },
+    "documents": { "totalDocuments": 50, ... },
+    "revenue": { "totalRevenue": 12345, ... }
+  },
+  "insights": [
+    { "title": "Baja captación de usuarios", "description": "..." }
+  ]
+}
+```
+
+Este endpoint puede integrarse en el Panel Maestro para mostrar sugerencias rápidas de acción.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,7 @@ import { posManagementRouter } from "./pos-management-routes";
 import { documentSignaturesRouter } from "./routes/document-signatures";
 import { secureDocumentRouter } from "./routes/secure-document-routes";
 import { qrSignatureRouter } from "./vecinos/qr-signature-routes";
+import strategicInsightsRouter from "./strategic-insights-routes";
 
 // Middleware de autenticación
 function isAuthenticated(req: Request, res: Response, next: any) {
@@ -73,6 +74,9 @@ export function registerRoutes(app: Express): Server {
   
   // Ruta para el sistema de firma con QR
   app.use("/api/qr-signature", qrSignatureRouter);
+
+  // Estrategia automatizada
+  app.use("/api", strategicInsightsRouter);
   
   // Ruta para servir archivos estáticos (documentos y contratos)
   app.use("/docs", express.static(path.join(process.cwd(), "docs")));

--- a/server/services/strategic-insight-service.ts
+++ b/server/services/strategic-insight-service.ts
@@ -1,0 +1,68 @@
+import { getUserActivityStats, getDocumentStats, getRevenueStats } from "../db";
+
+export interface Insight {
+  title: string;
+  description: string;
+}
+
+export interface StrategicInsights {
+  generatedAt: string;
+  metrics: {
+    users: Awaited<ReturnType<typeof getUserActivityStats>>;
+    documents: Awaited<ReturnType<typeof getDocumentStats>>;
+    revenue: Awaited<ReturnType<typeof getRevenueStats>>;
+  };
+  insights: Insight[];
+}
+
+export async function generateStrategicInsights(): Promise<StrategicInsights> {
+  const [users, documents, revenue] = await Promise.all([
+    getUserActivityStats(),
+    getDocumentStats(),
+    getRevenueStats()
+  ]);
+
+  const insights: Insight[] = [];
+
+  if (users.newUsersThisWeek < 5) {
+    insights.push({
+      title: "Baja captación de usuarios",
+      description:
+        "Se registraron menos de 5 usuarios nuevos esta semana. Considera campañas de marketing o programas de referidos para aumentar el registro."
+    });
+  } else {
+    insights.push({
+      title: "Crecimiento de usuarios",
+      description:
+        `Se registraron ${users.newUsersThisWeek} usuarios nuevos esta semana. Continúa con las acciones de adquisición.`
+    });
+  }
+
+  const pending = documents.documentsByStatus?.pending || 0;
+  if (pending > 50) {
+    insights.push({
+      title: "Documentos pendientes",
+      description:
+        `Existen ${pending} documentos pendientes. Revisa la disponibilidad de certificadores y ajusta la carga de trabajo.`
+    });
+  }
+
+  if (revenue.revenueThisMonth < revenue.revenueThisWeek * 4) {
+    insights.push({
+      title: "Ingresos por debajo de lo proyectado",
+      description:
+        "Los ingresos de este mes podrían estar por debajo de las expectativas. Evalúa nuevas estrategias comerciales o revisa la estructura de precios."
+    });
+  } else {
+    insights.push({
+      title: "Ingresos en línea",
+      description: "Los ingresos de este mes se mantienen acorde a lo planificado." 
+    });
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    metrics: { users, documents, revenue },
+    insights
+  };
+}

--- a/server/strategic-insights-routes.ts
+++ b/server/strategic-insights-routes.ts
@@ -1,0 +1,15 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { generateStrategicInsights } from "./services/strategic-insight-service";
+
+const router = Router();
+
+router.get("/strategic-insights", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const data = await generateStrategicInsights();
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/veci/client/src/pages/admin-dashboard.tsx
+++ b/veci/client/src/pages/admin-dashboard.tsx
@@ -755,7 +755,7 @@ export default function AdminDashboard() {
                     </div>
                   </CardContent>
                   <CardFooter className="border-t pt-4">
-                    <Link href="/admin/ai-insights">
+                    <Link href="/admin/ai-strategy">
                       <Button variant="outline" className="gap-2">
                         <Brain className="h-4 w-4" />
                         <span>Ver análisis completo de IA</span>


### PR DESCRIPTION
## Summary
- add server-side strategic insights service and route
- register strategic insights route
- fix admin dashboard links to AI strategy panel
- document the new API endpoint

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module '@shared/schema' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860303f6e8883268a9130d457cc9490